### PR TITLE
fix: 修复企业微信使用缓存中的 accesstoken 导致 jssdk 签名失败

### DIFF
--- a/packages/commons/src/api/QyJsTicketApi.ts
+++ b/packages/commons/src/api/QyJsTicketApi.ts
@@ -30,10 +30,13 @@ export class QyJsTicketApi {
     let cache: ICache = QyApiConfigKit.getCache
     let jsTicketJson: string = await cache.get(key)
     if (jsTicketJson) {
+      const jsTicketInstance = new JsTicket(jsTicketJson)
       if (QyApiConfigKit.isDevMode) {
         console.debug('缓存中获取api_ticket...')
       }
-      return new JsTicket(jsTicketJson)
+      if (jsTicketInstance.isAvailable()) {
+        return jsTicketInstance
+      }
     }
     // 通过接口获取
     let accessToken: AccessToken = await QyAccessTokenApi.getAccessToken()


### PR DESCRIPTION
close https://github.com/Javen205/TNWX/issues/24


参考 https://work.weixin.qq.com/api/doc/90000/90135/91039