### PR TITLE
获取小程序码时，参数有新增 

### DIFF
--- a/packages/miniprogram/src/MiniProgramApi.ts
+++ b/packages/miniprogram/src/MiniProgramApi.ts
@@ -241,6 +241,8 @@ export class MiniProgramApi {
    * @param autoColor
    * @param lineColor
    * @param isHyaline
+   * @param checkPath
+   * @param envVersion
    */
   public static async getUnlimited(
     scene: string,
@@ -248,7 +250,9 @@ export class MiniProgramApi {
     width: number = 430,
     autoColor: boolean = false,
     lineColor: object = { r: 0, g: 0, b: 0 },
-    isHyaline: boolean = false
+    isHyaline: boolean = false,
+    checkPath: boolean = true,
+    envVersion: MiniProgramEnvVersion
   ) {
     let accessToken = await AccessTokenApi.getAccessToken()
     let url = util.format(this.getUnlimitedUrl, (<AccessToken>accessToken).getAccessToken)
@@ -260,7 +264,9 @@ export class MiniProgramApi {
         width: width,
         auto_color: autoColor,
         line_color: lineColor,
-        is_hyaline: isHyaline
+        is_hyaline: isHyaline,
+        check_path: checkPath,
+        env_version: envVersion
       }),
       {
         headers: { 'Content-type': 'application/json' },
@@ -435,3 +441,6 @@ export enum MiniProgramMediaType {
   VOICE = 1,
   IMG = 2
 }
+
+
+type MiniProgramEnvVersion = 'release' | 'trial' | 'develop'


### PR DESCRIPTION
[小程序开发文档](https://developers.weixin.qq.com/miniprogram/dev/api-backend/open-api/qr-code/wxacode.getUnlimited.html)

+ `env_version` : 要打开的小程序版本。正式版为 "release"，体验版为 "trial"，开发版为 "develop"
+ `check_path` : 检查page 是否存在，为 true 时 page 必须是已经发布的小程序存在的页面（否则报错）；为 false 时允许小程序未发布或者 page 不存在， 但page 有数量上限（60000个）请勿滥用